### PR TITLE
Toegevoegd van reflectie overzicht pagina

### DIFF
--- a/app/Http/Controllers/ReflectionsController.php
+++ b/app/Http/Controllers/ReflectionsController.php
@@ -124,9 +124,9 @@ class ReflectionsController extends Controller
         }else return view('reflectionQuestions', ['question'=>$qi, 'ref_id' => $id]);
     }
 
-    public function getQuestionWithAnswer($) 
-    {
+    // public function getQuestionWithAnswer($) 
+    // {
 
-    }
+    // }
 
 }

--- a/app/Http/Controllers/ReflectionsController.php
+++ b/app/Http/Controllers/ReflectionsController.php
@@ -124,4 +124,9 @@ class ReflectionsController extends Controller
         }else return view('reflectionQuestions', ['question'=>$qi, 'ref_id' => $id]);
     }
 
+    public function getQuestionWithAnswer($) 
+    {
+
+    }
+
 }

--- a/app/Http/Controllers/ReflectionsController.php
+++ b/app/Http/Controllers/ReflectionsController.php
@@ -138,11 +138,14 @@ class ReflectionsController extends Controller
         }else return view('reflectionQuestions', ['question'=>$qi, 'ref_id' => $id]);
     }
 
-    public function getQuestionWithAnswer($questionId, $answerId) 
+    public function getQuestionWithAnswer(Request $request) 
     {
         try 
         {
-            $question = question::with(['question_open_answers', 'question_closed_answers'])->get();
+            $questionId = $request->query('questionId');
+            $answerId = $request->query('answerId');
+            
+            $question = question::with(['question_open_answers', 'question_closed_answers'])->where('id', $questionId)->first();
             $questionAnswer = null;
     
             if ($question->type == 'open_question' || $question->type == 'scale_question')
@@ -173,6 +176,7 @@ class ReflectionsController extends Controller
         catch (\Exception $e) {
             // Handle other exceptions
             Log::error('An error occurred: ' . $e->getMessage());
+            Log::error($e->getTrace());
             return response()->json(['error' => 'An error occurred'], 500); // Internal Server Error
         }
     }

--- a/app/Http/Controllers/ReflectionsTrajectoryController.php
+++ b/app/Http/Controllers/ReflectionsTrajectoryController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 use App\Models\Reflection;
 use App\Models\reflection_question;
 use App\Models\reflection_trajectory;
+use App\ViewModels\SummaryAnswerViewModel;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 
@@ -16,23 +17,21 @@ class ReflectionsTrajectoryController extends Controller
 
     public function showSummary($id)
     {
-        // $reflection = Reflection::where(['id','=',$id])->first();
-
-        // $reflectionQuestions = reflection_question::where('reflection_id', $id)->get();
-
-        // $questions = $reflectionQuestions->map(function ($reflectionQuestion) {
-        //     return $reflectionQuestion->question;
-        // });
-
         $reflectionQuestions = reflection_question::with(['question.question_open_answers', 'question.question_closed_answers'])
             ->where('reflection_id', $id)
             ->get();
 
         $questions = $reflectionQuestions->map(function ($reflectionQuestion) {
-            return $reflectionQuestion->question;
-        });
+            $question = $reflectionQuestion->question;
+            $answer = $question->type === 'open' ? $question->openAnswer : $question->closedAnswer;
 
-        Log::info($questions);
+            return new SummaryAnswerViewModel(
+                $question->id,
+                $question->title,
+                $answer ? $answer->text : null,
+                $question->type
+            );
+        });
 
         return view('reflectionSummary', compact('questions'));
     }

--- a/app/Http/Controllers/ReflectionsTrajectoryController.php
+++ b/app/Http/Controllers/ReflectionsTrajectoryController.php
@@ -2,14 +2,39 @@
 
 namespace App\Http\Controllers;
 use App\Models\Reflection;
+use App\Models\reflection_question;
 use App\Models\reflection_trajectory;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 
 class ReflectionsTrajectoryController extends Controller
 {
     public function showAll()
     {
         return view('welcome', ['ref_trajs' => reflection_trajectory::all()]);
+    }
+
+    public function showSummary($id)
+    {
+        // $reflection = Reflection::where(['id','=',$id])->first();
+
+        // $reflectionQuestions = reflection_question::where('reflection_id', $id)->get();
+
+        // $questions = $reflectionQuestions->map(function ($reflectionQuestion) {
+        //     return $reflectionQuestion->question;
+        // });
+
+        $reflectionQuestions = reflection_question::with(['question.question_open_answers', 'question.question_closed_answers'])
+            ->where('reflection_id', $id)
+            ->get();
+
+        $questions = $reflectionQuestions->map(function ($reflectionQuestion) {
+            return $reflectionQuestion->question;
+        });
+
+        Log::info($questions);
+
+        return view('reflectionSummary', compact('questions'));
     }
 
     public function showTrajectory($id)

--- a/app/Models/closed_answer.php
+++ b/app/Models/closed_answer.php
@@ -4,7 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
-class fclosed_answer extends Model
+class closed_answer extends Model
 {
     protected $fillable = [
         'question_id',

--- a/app/Models/reflection_question.php
+++ b/app/Models/reflection_question.php
@@ -10,4 +10,9 @@ class reflection_question extends Model
         'question_id',
         'reflection_id',
     ];
+
+    public function question()
+    {
+        return $this->belongsTo(question::class);
+    }
 }

--- a/app/ViewModels/SummaryAnswerViewModel.php
+++ b/app/ViewModels/SummaryAnswerViewModel.php
@@ -4,16 +4,12 @@ namespace App\ViewModels;
 
 class SummaryAnswerViewModel
 {
-    public $questionId;
-    public $title;
-    public $text;
-    public $type;
+    public $questionTitle;
+    public $answerText;
 
-    public function __construct($questionId, $title, $text, $type)
+    public function __construct($questionTitle, $answerText)
     {
-        $this->questionId = $questionId;
-        $this->title = $title;
-        $this->text = $text;
-        $this->type = $type;
+        $this->questionTitle = $questionTitle;
+        $this->answerText = $answerText;
     }
 }

--- a/app/ViewModels/SummaryAnswerViewModel.php
+++ b/app/ViewModels/SummaryAnswerViewModel.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\ViewModels;
+
+class SummaryAnswerViewModel
+{
+    public $questionId;
+    public $title;
+    public $text;
+    public $type;
+
+    public function __construct($questionId, $title, $text, $type)
+    {
+        $this->questionId = $questionId;
+        $this->title = $title;
+        $this->text = $text;
+        $this->type = $type;
+    }
+}

--- a/app/ViewModels/SummaryQuestionViewModel.php
+++ b/app/ViewModels/SummaryQuestionViewModel.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\ViewModels;
+
+class SummaryQuestionViewModel
+{
+    public $questionId;
+    public $answerId;
+    public $title;
+
+    public function __construct($questionId, $answerId, $title)
+    {
+        $this->questionId = $questionId;
+        $this->answerId = $answerId;
+        $this->title = $title;
+    }
+}

--- a/resources/js/reflectionSummary.js
+++ b/resources/js/reflectionSummary.js
@@ -19,8 +19,7 @@ async function getReflectionAnswer(questionId, answerId) {
             `/reflectionTrajectory/getQuestionWithAnswer?questionId=${questionId}&answerId=${answerId}`
         );
 
-        debugger;
-        const results = response.data;
+        const results = response.data.answer;
 
         return results;
     } catch (error) {
@@ -46,8 +45,8 @@ async function displayReflectionAnswer(questionId, answerId) {
     }
 
     if (reflectionAnswer != null) {
-        answerTitle.value = reflectionAnswer.questionTitle;
-        answerText = reflectionAnswer.answerText;
+        answerTitle.textContent = reflectionAnswer.questionTitle;
+        answerText.textContent = reflectionAnswer.answerText;
     } else {
         console.log("No answer found");
     }

--- a/resources/js/reflectionSummary.js
+++ b/resources/js/reflectionSummary.js
@@ -1,0 +1,34 @@
+import axios from "axios";
+
+async function getReflectionAnswer(questionId) {
+    try {
+        const response = await axios.get(
+            `/question/get/${$questionId}`
+        );
+
+        const results = response.data;
+
+        return results;
+    } catch (error) {
+        console.log("Failed sending request");
+        console.log(error.response);
+        throw error; // Rethrow the error to handle it in the calling function
+    }
+}
+
+function displayShareButton() {
+    shareBtn = document.getElementById('share-answer-btn');
+
+}
+
+async function displayReflectionAnswer(questionId) {
+    answerTitle = document.getElementById('selected-answer-title');
+    answerText = document.getElementById('selected-answer-text');
+
+    let reflectionAnswer = await getReflectionAnswer(questionId);
+
+    if (reflectionAnswer != null) {
+        answerTitle.value = reflectionAnswer.title;
+        answerText = reflectionAnswer.title
+    }
+}

--- a/resources/js/reflectionSummary.js
+++ b/resources/js/reflectionSummary.js
@@ -1,11 +1,25 @@
 import axios from "axios";
 
-async function getReflectionAnswer(questionId) {
+document.addEventListener("DOMContentLoaded", function () {
+    var questionListItems = document.querySelectorAll(".questionListItem");
+
+    questionListItems.forEach(function (element) {
+        element.addEventListener("click", function () {
+            let itemQuestionId = parseInt(element.getAttribute("questionId"));
+            let itemAnswerId = parseInt(element.getAttribute("answerId"));
+
+            displayReflectionAnswer(itemQuestionId, itemAnswerId);
+        });
+    });
+});
+
+async function getReflectionAnswer(questionId, answerId) {
     try {
         const response = await axios.get(
-            `/question/get/${$questionId}`
+            `/reflectionTrajectory/getQuestionWithAnswer?questionId=${questionId}&answerId=${answerId}`
         );
 
+        debugger;
         const results = response.data;
 
         return results;
@@ -17,18 +31,24 @@ async function getReflectionAnswer(questionId) {
 }
 
 function displayShareButton() {
-    shareBtn = document.getElementById('share-answer-btn');
-
+    shareBtn = document.getElementById("share-answer-btn");
 }
 
-async function displayReflectionAnswer(questionId) {
-    answerTitle = document.getElementById('selected-answer-title');
-    answerText = document.getElementById('selected-answer-text');
+async function displayReflectionAnswer(questionId, answerId) {
+    let answerTitle = document.getElementById("selected-answer-title");
+    let answerText = document.getElementById("selected-answer-text");
+    let reflectionAnswer;
 
-    let reflectionAnswer = await getReflectionAnswer(questionId);
+    if (answerId != 0) {
+        reflectionAnswer = await getReflectionAnswer(questionId, answerId);
+    } else {
+        reflectionAnswer = null;
+    }
 
     if (reflectionAnswer != null) {
-        answerTitle.value = reflectionAnswer.title;
-        answerText = reflectionAnswer.title
+        answerTitle.value = reflectionAnswer.questionTitle;
+        answerText = reflectionAnswer.answerText;
+    } else {
+        console.log("No answer found");
     }
 }

--- a/resources/views/reflectionSummary.blade.php
+++ b/resources/views/reflectionSummary.blade.php
@@ -1,4 +1,8 @@
 <x-layout>
+    <head>
+        @vite('resources/js/reflectionSummary.js')
+    </head>
+
     <div class="m-3 dark:text-white flex gap-8">
         <!-- Left side: Reflection title and text -->
         <div class="flex-1 p-6 bg-gray-900 rounded-lg shadow-lg">
@@ -26,7 +30,7 @@
             <ul>
                 @foreach($questions as $question)
                     <li class="mb-3 cursor-pointer">
-                        <a href="" type="{{ $question->type }}" class="hover:text-blue-400">
+                        <a class="questionListItem" questionId="{{ $question->questionId }}" answerId="{{ $question->answerId }}" class="hover:text-blue-400">
                             {{ $question->title }}
                         </a>
                     </li>

--- a/resources/views/reflectionSummary.blade.php
+++ b/resources/views/reflectionSummary.blade.php
@@ -1,0 +1,37 @@
+<x-layout>
+    <div class="m-3 dark:text-white flex gap-8">
+        <!-- Left side: Reflection title and text -->
+        <div class="flex-1 p-6 bg-gray-900 rounded-lg shadow-lg">
+            <h1 class="text-3xl font-bold mb-6">Samenvatting</h1>
+            <p class="mb-6">
+                Hier kan je een samenvatting vinden van alle geschreven reflecties. 
+                Voel je vrij om nog terug te gaan om het antwoord van de reflectie aan te passen. 
+                Hier heb je ook de mogelijkheid om een reflectie te kunnen delen, zodat andere jongeren 
+                extra inzichten kunnen krijgen door het inzien van het antwoord van jouw reflectie.
+            </p>
+            <div class="border-b border-gray-700 mb-6"></div>
+
+            <div>
+                <h2 id="selected-answer-title" class="text-2xl font-bold mb-4">Test reflectie</h2>
+                <p id="selected-answer-text" class="mb-4">Test antwoord</p>
+
+                <a id="share-answer-btn" href="" class="text-center bg-blue-500 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg">Deel antwoord</a>
+
+            </div>
+        </div>
+    
+        <!-- Right side: Reflection index -->
+        <div class="w-1/4 p-6 bg-gray-800 rounded-lg shadow-lg">
+            <h2 class="text-lg font-bold mb-4">Reflection Index</h2>
+            <ul>
+                @foreach($questions as $question)
+                    <li class="mb-3 cursor-pointer">
+                        <a href="" type="{{ $question->type }}" class="hover:text-blue-400">
+                            {{ $question->title }}
+                        </a>
+                    </li>
+                @endforeach
+            </ul>
+        </div>
+    </div>
+</x-layout>

--- a/resources/views/reflectionSummary.blade.php
+++ b/resources/views/reflectionSummary.blade.php
@@ -3,9 +3,9 @@
         @vite('resources/js/reflectionSummary.js')
     </head>
 
-    <div class="m-3 dark:text-white flex gap-8">
+    <div class="m-2 dark:text-white flex gap-3">
         <!-- Left side: Reflection title and text -->
-        <div class="flex-1 p-6 bg-gray-900 rounded-lg shadow-lg">
+        <div class="w-3/4 p-6 bg-gray-900 rounded-lg shadow-lg">
             <h1 class="text-3xl font-bold mb-6">Samenvatting</h1>
             <p class="mb-6">
                 Hier kan je een samenvatting vinden van alle geschreven reflecties. 
@@ -14,23 +14,22 @@
                 extra inzichten kunnen krijgen door het inzien van het antwoord van jouw reflectie.
             </p>
             <div class="border-b border-gray-700 mb-6"></div>
-
+    
             <div>
-                <h2 id="selected-answer-title" class="text-2xl font-bold mb-4">Test reflectie</h2>
-                <p id="selected-answer-text" class="mb-4">Test antwoord</p>
-
+                <h2 id="selected-answer-title" class="text-2xl font-bold mb-4"></h2>
+                <p id="selected-answer-text" class="mb-4"></p>
+    
                 <a id="share-answer-btn" href="" class="text-center bg-blue-500 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg">Deel antwoord</a>
-
             </div>
         </div>
     
         <!-- Right side: Reflection index -->
         <div class="w-1/4 p-6 bg-gray-800 rounded-lg shadow-lg">
-            <h2 class="text-lg font-bold mb-4">Reflection Index</h2>
+            <h2 class="text-lg font-bold mb-4">Beantwoordde vragen</h2>
             <ul>
                 @foreach($questions as $question)
                     <li class="mb-3 cursor-pointer">
-                        <a class="questionListItem" questionId="{{ $question->questionId }}" answerId="{{ $question->answerId }}" class="hover:text-blue-400">
+                        <a class="questionListItem block hover:text-blue-400" questionId="{{ $question->questionId }}" answerId="{{ $question->answerId }}">
                             {{ $question->title }}
                         </a>
                     </li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,7 +29,7 @@ Auth::routes();
 Route::get('/home', [App\Http\Controllers\HomeController::class, 'index'])->name('home');
 
 // Question routes
-Route::get('question/get/{$id}', [QuestionController::class, 'retrieveQuestion']);
+Route::get('question/get/{id}', [QuestionController::class, 'retrieveQuestion'])->name('question.retrieveQuestion');
 
 // Answer routes
 Route::get('answer/get', [AnswerController::class, 'get'])->name('answer.get');
@@ -55,9 +55,11 @@ Route::get('/', [ReflectionsTrajectoryController::class, 'showAll']);
 Route::post('/NewReflectionTrajectory', [ReflectionsTrajectoryController::class, 'store']);
 Route::get('/retrieveReflectionTrajectory/{id}', [ReflectionsTrajectoryController::class, 'retrieveReflectionTrajectory']);
 Route::get('/reflection/{id}',[]);
+Route::get('reflectionTrajectory/{id}/summary',[ReflectionsTrajectoryController::class,'showSummary'])->name('showSummary');
 Route::get('/reflectionTrajectory/{id}/{type}', [ReflectionsController::class, 'indexFromReflectiontrajectory']);
 Route::get('/reflectionTrajectory/{id}',[ReflectionsTrajectoryController::class,'showTrajectory']);
 Route::get('/retrieveAllReflectionTrajectories', [ReflectionsTrajectoryController::class, 'retrieveAll']);
+Route::get('/reflectionTrajectory/getQuestionWithAnswer', [ReflectionsTrajectoryController::class, 'getQuestionWithAnswer'])->name('getQuestionWithAnswer');
 
 Route::post('/answerMultipleChoice',[ReflectionsController::class, 'AnswerMultiQuestion']);
 Route::post('/answerOpenQuestion',[ReflectionsController::class, 'AnswerOpenQuestion']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -58,7 +58,7 @@ Route::get('reflectionTrajectory/{id}/summary',[ReflectionsTrajectoryController:
 Route::get('/reflectionTrajectory/{id}/{type}', [ReflectionsController::class, 'indexFromReflectiontrajectory']);
 Route::get('/reflectionTrajectory/{id}',[ReflectionsTrajectoryController::class,'showTrajectory']);
 Route::get('/retrieveAllReflectionTrajectories', [ReflectionsTrajectoryController::class, 'retrieveAll']);
-Route::get('/reflectionTrajectory/getQuestionWithAnswer', [ReflectionsTrajectoryController::class, 'getQuestionWithAnswer'])->name('getQuestionWithAnswer');
+Route::get('/reflectionTrajectory/getQuestionWithAnswer', [ReflectionsController::class, 'getQuestionWithAnswer'])->name('reflectionTrajectory.getQuestionWithAnswer');
 
 Route::post('/answerMultipleChoice',[ReflectionsController::class, 'AnswerMultiQuestion']);
 Route::post('/answerOpenQuestion',[ReflectionsController::class, 'AnswerOpenQuestion']);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,14 +1,18 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
+import tailwindcss from 'tailwindcss';
 
 export default defineConfig({
     plugins: [
         laravel({
             input: [
+                'resources/css/app.css',
                 'resources/sass/app.scss',
                 'resources/js/app.js',
+                'resources/js/*.js'
             ],
             refresh: true,
         }),
+        tailwindcss('./tailwind.config.js'),
     ],
 });


### PR DESCRIPTION
## Changelog

- Toegevoegd van overzicht pagina voor antwoorden bij reflecties
- Toegevoegd van logica voor ophalen vraag + antwoord
- Toegevoegd van logica voor ophalen van alle vragen + antwoord data bij een reflectie (showSummary view methode)
- Toegevoegd van viewmodels
- Toegevoegd van JS logica
- Opgelost van Tailwind configuratie die verkeerd was ingesteld

## Omschrijving
Toegevoegd van overzicht pagina die alle beantwoordde vragen bij een reflectie toont. Door het id van de reflectie in de URL mee te geven, wordt de betreffende reflectie opgehaald. Op deze wijze kan je voor een trajectory, de antwoorden van de 'past', 'present' en 'future' reflecties ophalen

### Belangrijk
- Binnen deze branch kwam ik erachter dat de Tailwind configuratie niet correct was ingesteld. Deze heb ik opgelost. Check met het testen of de styling van de website nog klopt
- Voor het makkelijk testen van deze branch, raad ik aan om eerst PR #45  te testen + uit te voeren voor testdata
- Pagina is momenteel alleen d.m.v de URL in de web.php te benaderen. Degene die verantwoordelijk is voor de front-end styling, zou deze pagina het beste aan de overige pagina's kunnen koppelen

## Documentatie
Geen