### PR TITLE
Opgelost + verbeterd summary page

### DIFF
--- a/app/Http/Controllers/AnswerController.php
+++ b/app/Http/Controllers/AnswerController.php
@@ -6,6 +6,8 @@ use App\Http\Controllers\Controller;
 use App\Models\closed_answer;
 use App\Models\open_answer;
 use App\Models\question_option;
+use App\Models\reflection_question;
+use App\ViewModels\SummaryQuestionViewModel;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
@@ -114,5 +116,38 @@ class AnswerController extends Controller
         ]);
 
         return $openAnswer;
+    }
+
+    public function retrieveQuestionsWithAnswers($reflectionId, $userId) {
+        $reflectionQuestions = reflection_question::with(['question.question_open_answers', 'question.question_closed_answers'])
+        ->where('reflection_id', $reflectionId)
+        ->get();
+
+        $questions = $reflectionQuestions->map(function ($reflectionQuestion) use ($userId) {
+            $question = $reflectionQuestion->question;
+            $answers = $question->type === 'open_question' ? $question->question_open_answers : $question->question_closed_answers;
+
+            $filteredAnswers = $answers->where('user_id', $userId);
+
+            $answer = $filteredAnswers->first();
+            $answerId = null;
+
+            if ($answer) 
+            {
+                $answerId = $answer->id;
+            }
+            else 
+            {
+                $answerId = 0;
+            }
+
+            return new SummaryQuestionViewModel(
+                $question->id,
+                $answerId,
+                $question->title,
+            );
+        });
+
+        return $questions;
     }
 }

--- a/app/Http/Controllers/QuestionController.php
+++ b/app/Http/Controllers/QuestionController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Http\Controllers\Controller;
 use App\Models\question;
 use App\Models\question_option;
+use App\Models\reflection_question;
 use Illuminate\Http\Request;
 
 class QuestionController extends Controller
@@ -25,5 +26,19 @@ class QuestionController extends Controller
         $question = question::findOrFail($id);
         return $question;
     }
-    //
+    
+    public function generateReflectionQuestions($reflectionId, $referenceType)
+    {
+        $questionsToLink = null;
+
+        $questionsToLink = question::where('ref_type', $referenceType)->pluck('id');
+
+        foreach ($questionsToLink as $questionId) 
+        {
+            reflection_question::create([
+                'reflection_id' => $reflectionId,
+                'question_id' => $questionId,
+            ]);
+        }
+    }
 }

--- a/app/Http/Controllers/ReflectionsTrajectoryController.php
+++ b/app/Http/Controllers/ReflectionsTrajectoryController.php
@@ -19,39 +19,11 @@ class ReflectionsTrajectoryController extends Controller
 
     public function showSummary($id)
     {
-        $reflectionQuestions = reflection_question::with(['question.question_open_answers', 'question.question_closed_answers'])
-            ->where('reflection_id', $id)
-            ->get();
-        
         $user = auth()->user();
+        $userId = $user->id;
 
-        // $userId = $user->id;
-        $userId = 1; // Demo value till login functionality is made
-
-        $questions = $reflectionQuestions->map(function ($reflectionQuestion) use ($userId) {
-            $question = $reflectionQuestion->question;
-            $answers = $question->type === 'open_question' ? $question->question_open_answers : $question->question_closed_answers;
-
-            $filteredAnswers = $answers->where('user_id', $userId);
-
-            $answer = $filteredAnswers->first();
-            $answerId = null;
-
-            if ($answer) 
-            {
-                $answerId = $answer->id;
-            }
-            else 
-            {
-                $answerId = 0;
-            }
-
-            return new SummaryQuestionViewModel(
-                $question->id,
-                $answerId,
-                $question->title,
-            );
-        });
+        $answerController = new AnswerController();
+        $questions = $answerController->retrieveQuestionsWithAnswers($id, $userId);
 
         return view('reflectionSummary', compact('questions'));
     }


### PR DESCRIPTION
Verbeterd van de koppeling tussen de reflecties en de summary page (samenvattingspagina einde reflectie). Antwoorden worden nu correct getoond bij de vragen.

Ook is er een verbetering gemaakt om correct vragen te koppelen aan een reflectie aan de start van een reflectie