### PR TITLE
Afgerond van 'deel samenvattingen' functionaliteit

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -23,6 +23,22 @@ class HomeController extends Controller
      */
     public function index()
     {
-        return view('home');
+        \Log::info('Showing user profile for user');
+
+        $summaries = refl
+
+        return view('home', ['summaries' => $summaries]);
+    }
+
+    /**
+     * Share the summary.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Contracts\Support\Renderable
+     */
+    public function shareSummary($id)
+    {
+        \Log::info("Sharing summary");
+        // Your code here
     }
 }

--- a/app/Models/Reflection.php
+++ b/app/Models/Reflection.php
@@ -10,8 +10,20 @@ class Reflection extends Model
         'reflection_type',
         'reflection_trajectory_id',
     ];
+    
     public function reflection_progression()
     {
         return $this->hasOne(reflection_progression::class);
+    }
+    
+    public function reflection_trajectory()
+    {
+        return $this->belongsTo(reflection_trajectory::class, 'reflection_trajectory_id', 'id');
+    }
+
+    // Add this relationship to link Reflection with reflection_summary
+    public function reflection_summaries()
+    {
+        return $this->hasMany(reflection_summary::class);
     }
 }

--- a/app/Models/reflection_summary.php
+++ b/app/Models/reflection_summary.php
@@ -5,12 +5,34 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * Class reflection_summary
+ *
+ * @package App\Models
+ *
+ * @property int $id
+ * @property string $summary
+ * @property int $reflection_id
+ * @property int $user_id
+ * @property bool $shared
+ * @property \App\Models\Reflection $reflection
+ */
 class reflection_summary extends Model
 {
     protected $fillable = [
         'summary',
         'reflection_id',
         'user_id',
+        'shared'
     ];
+    
     use HasFactory;
+    
+    /**
+     * Get the reflection that owns the reflection summary.
+     */
+    public function reflection()
+    {
+        return $this->belongsTo(Reflection::class, 'reflection_id', 'id');
+    }
 }

--- a/app/View/profile/ProfileSummaryCard.php
+++ b/app/View/profile/ProfileSummaryCard.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\View\Components\profile;
+
+use Closure;
+use Illuminate\View\Component;
+use Illuminate\Contracts\View\View;
+
+class ProfileSummaryCard extends Component
+{
+    public $summary;
+
+    public function __construct($summary)
+    {
+        $this->summary = $summary;
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View|Closure|string
+    {
+        return view('components.profile-summary-card');
+    }
+}

--- a/app/ViewModels/SummaryCardViewModel.php
+++ b/app/ViewModels/SummaryCardViewModel.php
@@ -1,0 +1,27 @@
+<?php
+
+
+namespace App\ViewModels;
+
+use Illuminate\Support\Str;
+use Carbon\Carbon;
+
+class SummaryCardViewModel
+{
+    public $summaryId;
+    public $title; // Summary reflection subject
+    public $reflection; // Summary reflection type
+    public $text; // Summary reflection content (text)
+    public $createdDate;
+    public $isShared;
+
+    public function __construct($summaryId=null, $title=null, $reflection=null, $text=null, $createdDate=null, $isShared=null)
+    {
+        $this->summaryId = $summaryId;
+        $this->title = $title;
+        $this->reflection = $reflection;
+        $this->text = $text;
+        $this->createdDate = Carbon::parse($createdDate)->format('d-m-Y');
+        $this->isShared = $isShared;
+    }
+}

--- a/database/migrations/2023_11_30_113324_add_reflection_summary_shared.php
+++ b/database/migrations/2023_11_30_113324_add_reflection_summary_shared.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('reflection_summaries', function (Blueprint $table) {
+            $table->boolean('shared')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('reflection_summaries', function (Blueprint $table) {
+            $table->dropColumn('shared');
+        });
+    }
+};

--- a/resources/js/profile/userProfile.js
+++ b/resources/js/profile/userProfile.js
@@ -1,0 +1,58 @@
+import { displayErrorToast, displaySuccessToast } from "../shared/toaster";
+
+let shareReflectionBtn;
+
+document.addEventListener("DOMContentLoaded", () => {
+    shareReflectionBtn = document.querySelector(".share-reflection-btn");
+    const summaryId = shareReflectionBtn.getAttribute("summary-id");
+
+    shareReflectionBtn.addEventListener("click", () => {
+        // Disable the button to prevent multiple clicks
+        shareReflectionBtn.disabled = true;
+        shareSummary(summaryId);
+    });
+});
+
+function shareSummary(summaryId) {
+    axios
+        .post("/home/shareSummary", { summaryId })
+        .then((response) => {
+            if (response.status === 200) {
+                console.log(response.data.message);
+                if (response.data.message === "Summary shared successfully") {
+                    const shared = response.data.shared;
+                    const successMessage = shared ? "Samenvatting gedeeld" : "Samenvatting teruggedraaid";
+                    displaySuccessToast(successMessage);
+                    updateShareButtonStyle(shared);
+                }
+            } else {
+                console.error("An error occurred while sharing the summary");
+                displayErrorToast(
+                    "Er is iets fout gegaan met het delen van de samenvatting"
+                );
+            }
+        })
+        .catch((error) => {
+            console.error(error);
+            displayErrorToast(
+                "Er is iets fout gegaan met het delen van de samenvatting"
+            );
+        })
+        .finally(() => {
+            // Enable the button after the request is completed
+            shareReflectionBtn.disabled = false;
+        });
+}
+
+function updateShareButtonStyle(shared) {
+    const shareReflectionBtn = document.querySelector(".share-reflection-btn");
+    if (shared) {
+        shareReflectionBtn.classList.remove("bg-blue-500", "hover:bg-blue-700");
+        shareReflectionBtn.classList.add("bg-blue-300", "hover:bg-blue-500");
+        shareReflectionBtn.textContent = "Gedeeld";
+    } else {
+        shareReflectionBtn.classList.remove("bg-blue-300", "hover:bg-blue-500");
+        shareReflectionBtn.classList.add("bg-blue-500", "hover:bg-blue-700");
+        shareReflectionBtn.textContent = "Reflectie delen";
+    }
+}

--- a/resources/js/reflectionSummary.js
+++ b/resources/js/reflectionSummary.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import Toastify from "toastify-js";
+import { displayErrorToast, displaySuccessToast } from "./shared/toaster";
 
 document.getElementById("summary-btn").addEventListener("click", function () {
     generateReflectionSummary(getReflectionId());
@@ -18,28 +18,6 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 });
 
-function displaySuccessSummary() {
-    Toastify({
-        text: "Samenvatting wordt gegenereerd",
-        duration: 3000,
-        gravity: "top",
-        position: "right",
-        className: "success-toast",
-        onClick: function () {}, // Callback after click
-    }).showToast();
-}
-
-function displayErrorSummary() {
-    Toastify({
-        text: "Er is iets fout gegaan met het genereren van de samenvatting",
-        duration: 3000,
-        gravity: "top",
-        position: "right",
-        className: "fail-toast",
-        onClick: function () {}, // Callback after click
-    }).showToast();
-}
-
 function getReflectionId() {
     let reflectionId = document.getElementById("reflection-id").value;
 
@@ -49,7 +27,7 @@ function getReflectionId() {
 async function generateReflectionSummary(reflectionId) {
     try {
         console.log("Foo");
-        displaySuccessSummary();
+        displaySuccessToast("Samenvatting wordt gegenereerd");
 
         const response = await axios.post(
             `/insights/generateReflectionSummary?`,
@@ -60,15 +38,15 @@ async function generateReflectionSummary(reflectionId) {
 
         // 'fire and forget' functionaliteit werkt niet zonder een framework als RabbitMQ. Vandaar standaard succes message
         // if (response.data >= 200 && response.data < 300) {
-        //     displaySuccessSummary();
+        //     displaySuccessToast("Samenvatting wordt gegenereerd");
         // } else {
         //     console.error('Request failed with status code:', response.data);
-        //     displayErrorSummary();
+        //     displayErrorToast("Er is iets fout gegaan met het genereren van de samenvatting");
         // }
     } catch (error) {
         console.log("Failed sending request");
         console.log(error.response);
-        displayErrorSummary();
+        displayErrorToast("Er is iets fout gegaan met het genereren van de samenvatting");
         throw error; // Rethrow the error to handle it in the calling function
     }
 }

--- a/resources/js/shared/toaster.js
+++ b/resources/js/shared/toaster.js
@@ -1,0 +1,31 @@
+import Toastify from "toastify-js";
+
+export function displaySuccessToast(toastMessage, callback = null) {
+    Toastify({
+        text: toastMessage,
+        duration: 3000,
+        gravity: "top",
+        position: "right",
+        className: "success-toast",
+        onClick: () => {
+            if (callback !== null) {
+                callback();
+            }
+        }, // Callback after click
+    }).showToast();
+}
+
+export function displayErrorToast(toastMessage, callback = null) {
+    Toastify({
+        text: toastMessage,
+        duration: 3000,
+        gravity: "top",
+        position: "right",
+        className: "fail-toast",
+        onClick: () => {
+            if (callback !== null) {
+                callback();
+            }
+        }, // Callback after click
+    }).showToast();
+}

--- a/resources/views/Components/profile-summary-card.blade.php
+++ b/resources/views/Components/profile-summary-card.blade.php
@@ -1,7 +1,7 @@
 <div class="block bg-white rounded-lg shadow-md cursor-pointer summary-card">
     <div class="p-4">
         <h2 class="text-lg font-semibold mb-2">{{ $summary->title }}</h2> 
-        <p class="text-gray-600">{{ $summary->reflection }}</p>
+        <p class="text-gray-600">Type reflectie: {{ $summary->type }}</p>
         <p class="text-gray-700">{{ Str::limit($summary->text, 150) }}</p>
     </div>
     <div class="p-4 border-t border-gray-300">
@@ -9,9 +9,13 @@
         $createdDate = \Carbon\Carbon::parse($summary->created_on);
         @endphp
 
-        <p class="text-gray-400 text-sm italic">Created on: {{ $createdDate->format('d-m-Y') }}</p>
+        <p class="text-gray-400 text-sm italic">Aangemaakt op: {{ $createdDate->format('d-m-Y') }}</p>
     </div>
     <div class="p-4">
-        <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" onclick="window.location='{{ route('home.shareSummary', $summary->id) }}'">Share</button>
+        @if ($summary->isShared)
+            <button summary-id="{{ $summary->summaryId }}" class="share-reflection-btn bg-blue-300 hover:bg-blue-500 text-white font-bold py-2 px-4 rounded">Gedeeld</button>
+        @else
+            <button summary-id="{{ $summary->summaryId }}" class="share-reflection-btn bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">Reflectie delen</button>
+        @endif
     </div>
 </div>

--- a/resources/views/Components/profile-summary-card.blade.php
+++ b/resources/views/Components/profile-summary-card.blade.php
@@ -1,0 +1,17 @@
+<div class="block bg-white rounded-lg shadow-md cursor-pointer summary-card">
+    <div class="p-4">
+        <h2 class="text-lg font-semibold mb-2">{{ $summary->title }}</h2> 
+        <p class="text-gray-600">{{ $summary->reflection }}</p>
+        <p class="text-gray-700">{{ Str::limit($summary->text, 150) }}</p>
+    </div>
+    <div class="p-4 border-t border-gray-300">
+        @php
+        $createdDate = \Carbon\Carbon::parse($summary->created_on);
+        @endphp
+
+        <p class="text-gray-400 text-sm italic">Created on: {{ $createdDate->format('d-m-Y') }}</p>
+    </div>
+    <div class="p-4">
+        <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" onclick="window.location='{{ route('home.shareSummary', $summary->id) }}'">Share</button>
+    </div>
+</div>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,6 +1,10 @@
 @extends('layouts.app')
 
 @section('content')
+<head>
+    @vite('resources/js/profile/userProfile.js')
+</head>
+
 <div class="container">
     <div class="row justify-content-center">
         <div class="col-md-8">
@@ -19,7 +23,7 @@
             </div>
         </div>
 
-        <div class="user-summaries">
+        <div class="user-summaries flex">
             @foreach ($summaries as $summary)
                 <x-profile-summary-card :summary="$summary" />
             @endforeach

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -18,6 +18,12 @@
                 </div>
             </div>
         </div>
+
+        <div class="user-summaries">
+            @foreach ($summaries as $summary)
+                <x-profile-summary-card :summary="$summary" />
+            @endforeach
+        </div>
     </div>
     <button onclick="window.location.href='/'">
         <h1 class="focus:outline-none px-4 bg-gray-900 p-3 ml-3 rounded-lg text-white hover:bg-gray-800 text-primary-500  mb-8 text-4xl font-extrabold tracking-tight lg:text-4xlxl dark:text-white text-gray-900">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -77,4 +77,25 @@
         </main>
     </div>
 </body>
+
+{{-- Styling for shared toaster functionality --}}
+<style>
+    .success-toast {
+        background: #3c84fa;
+        background-color: #3c84fa;
+        width: 100%;
+        color: white;
+        font-size: 20px;
+        text-align: center;
+    }
+
+    .fail-toast {
+        background: rgb(197, 67, 67);
+        background-color: rgb(197, 67, 67);
+        width: 100%;
+        color: white;
+        font-size: 20px;
+        text-align: center;
+    }
+</style>
 </html>

--- a/resources/views/reflectionSummary.blade.php
+++ b/resources/views/reflectionSummary.blade.php
@@ -42,23 +42,24 @@
         </div>
     </div>
 
-    <style>
-        .success-toast {
-            background: #3c84fa;
-            background-color: #3c84fa;
-            width: 100%;
-            color: white;
-            font-size: 20px;
-            text-align: center;
-        }
+{{-- Styling for toaster functionality --}}
+<style>
+    .success-toast {
+        background: #3c84fa;
+        background-color: #3c84fa;
+        width: 100%;
+        color: white;
+        font-size: 20px;
+        text-align: center;
+    }
 
-        .fail-toast {
-            background: rgb(197, 67, 67);
-            background-color: rgb(197, 67, 67);
-            width: 100%;
-            color: white;
-            font-size: 20px;
-            text-align: center;
-        }
-    </style>
+    .fail-toast {
+        background: rgb(197, 67, 67);
+        background-color: rgb(197, 67, 67);
+        width: 100%;
+        color: white;
+        font-size: 20px;
+        text-align: center;
+    }
+</style>
 </x-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,7 +28,7 @@ Route::get('/', function () {
 Auth::routes();
 
 Route::get('/home', [App\Http\Controllers\HomeController::class, 'index'])->name('home');
-Route::get('/home/shareSummary/{id}', [App\Http\Controllers\HomeController::class, 'shareSummary'])->name('home.shareSummary');
+Route::post('/home/shareSummary', [App\Http\Controllers\HomeController::class, 'shareSummary'])->name('home.shareSummary');
 
 // Question routes
 Route::get('question/get/{id}', [QuestionController::class, 'retrieveQuestion'])->name('question.retrieveQuestion');

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,6 +27,7 @@ Route::get('/', function () {
 Auth::routes();
 
 Route::get('/home', [App\Http\Controllers\HomeController::class, 'index'])->name('home');
+Route::get('/home/shareSummary/{id}', [App\Http\Controllers\HomeController::class, 'shareSummary'])->name('home.shareSummary');
 
 // Question routes
 Route::get('question/get/{id}', [QuestionController::class, 'retrieveQuestion'])->name('question.retrieveQuestion');


### PR DESCRIPTION
## Changelog
- Functionaliteit voor het tonen van eigen samenvattingen in profiel
- Model aanpassingen voor relaties samenvatting + reflectie
- Migratie voor 'shared' property bij samenvattingen
- Dynamische JS functionaliteit voor het delen / 'ondelen' van samenvattingen
- Verbeterd van JS toaster functionaliteit

## Omschrijving
Toegevoegd van functionaliteit voor het inzien + delen van eigen samenvattingen. Op deze manier is de functionaliteit voor het maken + tonen van eigen samenvattingen rond. Op basis van deze functionaliteit kunnen ook verdere stappen gemaakt worden voor het tonen van gedeelde samenvattingen.

### Styling
De profielpagina lijkt momenteel met Bootstrap styling gemaakt te zijn, waardoor de styling voor de samenvattingen (Tailwind) niet correct werkt. Met de revamp van de profielpagina zou hier ook rekening mee gehouden moeten worden

## Documentatie
Geen